### PR TITLE
Add build and install scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components/*
+distro/
 *.swp

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Percona Platform",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "homepage": "https://github.com/percona/platform",
   "authors": [
     "Andrii Skomorokhov <andrii.skomorokhov@percona.com>"

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,137 @@
+#!/bin/sh
+
+# Copyright (c) 2015, Percona LLC and/or its affiliates. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+DEV="${DEV:-""}"
+DIRTY_BUILD="${DIRTY_BUILD:-"no"}"
+
+if [ $# -eq 1 -a "$1" = "help" ]; then
+   echo "Usage: $0"
+   echo
+   echo "This script must be ran from the root or scripts/ dir."
+   exit 0
+fi
+
+set -eu
+
+err() {
+   echo "ERROR: $@" >&2
+   exit 1
+}
+
+BIN="percona-qan-app"
+
+if [ -f "build" -a -f "install" ]; then
+   cd ..
+fi
+
+if [ -f "bower.json" ]; then
+   ROOT_DIR="$PWD"
+else
+   err "Run this script from the percona/platform-app directory."
+fi
+
+if [ -z "$(which bower)" ]; then
+   err "Bower is not installed. Run 'npm install -g bower' to install it."
+fi
+
+cd "$ROOT_DIR"
+
+# Determine if this is a dev or release build. A release build requires using
+# the master branch that's tagged with the same version in conf/app.conf. Else,
+# we presume dev build.
+VER="$(awk -F: '/version/ {print $2}' bower.json | sed -e 's/[^0-9.]*//g')"
+REV="$(git log -n 1 --no-walk --pretty="%h")"
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$BRANCH" = "master" -a "$DEV" = "" ]; then
+   # git log -n 1 --no-walk --tags --pretty="%h %d" --decorate=full
+   # 1475390  (HEAD, tag: refs/tags/v1.0.0, refs/remotes/origin/master, refs/heads/master, refs/heads/foo)
+   latestTag="$(git log -n 1 --no-walk --tags --pretty="%h %d" --decorate=full)"
+   tagRev="$(echo "$latestTag" | awk '{print $1}')"
+   tagVer="$(echo "$latestTag" | perl -n -e '/refs\/tags\/v([\d\.]+)/ && print $1')"
+   if [ "$tagVer" -a "$tagRev" = "$REV" ]; then
+      if [ "$tagVer" != "$VER" ]; then
+         err "Version mismatch: bower.json has v$VER, but git tag has v$tagVer"
+      else
+         dirty="$(git status --porcelain)"
+         if [ "$dirty" ]; then
+            if [ "$DIRTY_BUILD" = "no" ]; then
+               err "Cannot do release build because this is the master branch with version" \
+                  "tag v$tagVer but there are uncommitted changes or untracked files" \
+                  "(see 'git status'). If the latest commit is not v$tagVer, remove the tag (git tag -d v$tagVer);" \
+                  "else, add and commit all changes, then re-tag the latest commit" \
+                  "(git tag -a v$tagVer -m \"v$tagVer\"). Or, specify DIRTY_BUILD=yes to force" \
+                  "the release build (not recommended)."
+            else
+               echo "Dirty release build of master branch v$VER"
+            fi
+         else
+            echo "Release build of master branch v$VER"
+         fi
+         DEV="no"
+      fi
+   else
+      echo "Dev build of master branch @ $REV (latest commit has no version tag)"
+   fi
+else
+   echo "Dev build of $BRANCH branch @ $REV"
+fi
+
+# To distinguish dev and release builds, we append "-date.revision" to dev builds,
+# e.g. release 1.0.0 = "1.0.0", but dev 1.0.0 = "1.0.0-20150825.a73cd9e".
+if [ "$DEV" = "yes" ]; then
+   ymd="$(TZ="UTC" date "+%Y%m%d")"
+   VER="$VER-$ymd.$REV"
+fi
+
+# Install/update JS deps.
+bower install
+
+# Set up the distro dir.
+DISTRO_DIR="$ROOT_DIR/distro/$BIN-$VER"
+[ ! -d "distro" ] && mkdir distro
+[ -d "$DISTRO_DIR" ] && rm -rf "$DISTRO_DIR"
+mkdir "$DISTRO_DIR"
+cd "$DISTRO_DIR"
+
+# Copy the scripts, but remove this build script.
+cp "$ROOT_DIR/scripts/"* .
+rm build
+
+# Copy index.hml replacing "v<version>" with this version.
+sed -e "s/v[0-9].[0-9].[0-9]/v$VER/" "$ROOT_DIR/index.html" > index.html
+
+# Copy the AngularJS app.
+cp -R "$ROOT_DIR/client" ./client/
+
+# Copy only the needed 3rd-party JS scripts, i.e. ones loaded by index.html.
+mkdir bower_components
+for file in $(perl -ne 'm/(bower_components[^"]+)/ and print $1, "\n"' "$ROOT_DIR/index.html"); do
+   dir="$(dirname $file)"
+   mkdir -p "$dir"
+   cp "$ROOT_DIR/$file" "$dir"
+done
+
+# Copy all of Bootstrap.
+cp -R "$ROOT_DIR/bower_components/bootstrap/dist/"* bower_components/bootstrap/dist
+
+# Go up one dir to distro/ and tarball the disto dir.
+cd ..
+tar cvfz $BIN-$VER.tar.gz $BIN-$VER/ > /dev/null
+
+echo
+echo "Done building distro/$BIN-$VER.tar.gz"
+echo

--- a/scripts/install
+++ b/scripts/install
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2015, Percona LLC and/or its affiliates. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+set -ue
+
+BASEDIR="${BASEDIR:-"/usr/local/percona/qan-app"}"
+PORT="${PORT:-"8000"}"
+CHECK_REQ="${CHECK_REQ:-"yes"}"
+
+err() {
+   echo "ERROR: $*" >&2
+   exit 1
+}
+
+usage() {
+   echo "Usage: $0 [command]"
+   echo
+   echo "Commands:"
+   echo "  check    Check requirements"
+   echo "  help     Print this"
+   echo
+   echo "Environment variables:"
+   echo "  BASEDIR    ($BASEDIR)"
+   echo "  PORT       ($PORT)"
+}
+
+app_is_running() {
+   APP_PID="$(ps ax | grep "python -m SimpleHTTPServer $PORT" | grep -v grep | awk '{print $1}')"
+   [ "$APP_PID" ] && return 0 # running
+   return 1 # not running
+}
+
+run_app() {
+   app_is_running \
+      && err "Percona QAN App is already running (PID $APP_PID). Use the 'killall' command and try again."
+
+   # Run the API (via Revel) and the consumers.
+   (
+      cd "$BASEDIR"
+      ./start > /dev/null
+      if [ $? -eq 0 ]; then
+         echo "Started Percona QAN App on port $PORT. To check its log file:"
+         echo
+         echo "  tail -f $BASEDIR/percona-qan-app.log"
+         echo
+      fi
+   )
+}
+
+check_req() {
+   echo "Checking requirements..."
+
+   # 'python --version' prints to stderr, which is silly imho, because if we
+   # 2>&1 and check that we might false-positive on "command not found".
+   if [ -z "$(which python)" ]; then
+      echo
+      echo "Python is not installed or in the PATH." >&2
+      return 1
+   else
+      echo "OK: Python is installed"
+   fi
+
+   return 0
+}
+
+kill_all() {
+   killall percona-datastore 2>/dev/null    || true
+   killall revel 2>/dev/null                || true
+}
+
+# ###########################################################################
+# Execution starts here
+# ###########################################################################
+
+SCRIPT_DIR="$(dirname $0)"
+cd "$SCRIPT_DIR"
+
+if [ $# -eq 0 ]; then 
+   # Check system requirements, best effort to ensure install will succeed.
+   if [ "$CHECK_REQ" = "yes" ]; then
+      check_req || exit 1
+   fi
+
+   # Stop datastore if it's running, else cp will throw error:
+   # cp: cannot create regular file `/usr/local/percona/datastore/percona-datastore': Text file busy
+   if app_is_running; then
+      echo "The app is already running, stopping it..."
+      kill_all
+   fi
+
+   echo "Installing Percona QAN App..."
+
+   if [ ! -d "$BASEDIR" ]; then
+      mkdir -p "$BASEDIR" || err "Cannot create $BASEDIR"
+   fi
+
+   # Test privs on the basedir, else cp -r will spew errors.
+   touch "$BASEDIR/fipar" || err "Cannot write to $BASEDIR"
+   rm "$BASEDIR/fipar"    || err "fipar cannot be removed"
+
+   cp -r * "$BASEDIR"
+   rm "$BASEDIR/install"
+
+   sed -e "s/:PORT/$PORT/g" "./start" > "$BASEDIR/start"
+   sed -e "s/:PORT/$PORT/g" "./stop" > "$BASEDIR/stop"
+
+   run_app 
+
+elif [ $# -eq 1 ]; then
+   case $1 in
+      help)
+         usage
+         exit 0
+         ;;
+      check)
+         if check_req; then
+            exit 0
+         else
+            exit 1
+         fi
+         ;;
+      *)
+         echo "Unknown command: '$1'" >&2
+         echo "Run without arguments to list commands." >&2
+         exit 1
+         ;;
+   esac
+else
+   usage
+   exit 1
+fi

--- a/scripts/start
+++ b/scripts/start
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+BASEDIR=$(cd "$(dirname "$0")"; pwd)
+PORT="${PORT:-":PORT"}"
+
+app_is_running() {
+   pid="$(ps ax | grep "python -m SimpleHTTPServer $PORT" | grep -v grep | awk '{print $1}')"
+   [ "$pid" ] && return 0 # running
+   return 1 # not running
+}
+
+if app_is_running; then
+   kill $pid
+fi
+
+python -m SimpleHTTPServer $PORT >> percona-qan-app.log 2>&1 &
+pid=$!
+if [ $? -ne 0 ]; then
+   echo "Error started Percona QAN app. Check the log file: $BASEDIR/percona-qan-app.log" >&2
+   exit 1
+fi
+echo "Percona QAN App running as PID $pid"

--- a/scripts/stop
+++ b/scripts/stop
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+BASEDIR=$(cd "$(dirname "$0")"; pwd)
+PORT="${PORT:-":PORT"}"
+
+app_is_running() {
+   pid="$(ps ax | grep "python -m SimpleHTTPServer $PORT" | grep -v grep | awk '{print $1}')"
+   [ "$pid" ] && return 0 # running
+   return 1 # not running
+}
+
+if app_is_running; then
+   kill $pid
+   echo "Stopped Percona QAN App"
+else
+   echo "Percona QAN App is not running"
+fi


### PR DESCRIPTION
Install script for a consistent install experience for agent, datastore, and app. Uses `/usr/local/percona` as root dir. Checks requirements, etc.

The build script also packages only the `bower_components` that are needed.
