### PR TITLE
Allow extending app with new instance types

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -108,25 +108,25 @@
                     return Instance.query()
                           .$promise
                           .then(function(resp) {
-                              var mysqls = [];
+                              var instances = [];
                               for (var i=0; i < resp.length; i++) {
-                                  // if deleted - skip
-                                  if (resp[i].Subsystem === 'mysql') {
-                                      mysqls.push(resp[i]);
+                                  if (resp[i].Subsystem === 'os' || resp[i].Subsystem === 'agent') {
+                                      continue;
                                   }
+                                  instances.push(resp[i]);
                               }
-                              if (mysqls.length === 0) {
+                              if (instances.length === 0) {
                                   $rootScope.alerts.push({
-                                      msg: 'There are no MySQL instances.',
+                                      msg: 'There are no instances.',
                                       type: 'danger'
                                   });
                                   $rootScope.connection_error = true;
                               }
 
-                              $rootScope.instance = mysqls[0];
+                              $rootScope.instance = instances[0];
                               return {
-                                  instances: mysqls,
-                                  selected_instance: mysqls[0]
+                                  instances: instances,
+                                  selected_instance: instances[0]
                               };
                           })
                           .catch(function(resp, err){

--- a/client/app/controllers.js
+++ b/client/app/controllers.js
@@ -830,7 +830,9 @@
                 $state, Instance, AgentCmd, AgentStatus, AgentLog, Config, instances) {
                 $scope.init = function () {
                     $scope.DEMO = constants.DEMO;
-                    $scope.instances = instances.asArray.filter(function(i) { return i.Subsystem === 'mysql';});
+                    $scope.instances = instances.asArray.filter(function(i) {
+                        return i.Subsystem !== 'os' && i.Subsystem !== 'agent';
+                    });
                     $scope.agents = instances.asArray.filter(function(i) { return i.Subsystem === 'agent';});
                     $rootScope.instances = $scope.instances;
                     $scope.allInstances = instances.asArray;
@@ -875,20 +877,19 @@
                                         .finally(function() {});
                                     }, 200);
                                     break;
-                                    case 'server-info':
-                                        $timeout(function () {
-                                        for (var i = 0; i < $scope.agents.length; i++) {
-                                            if ($scope.agents[i].ParentUUID === $scope.instance.ParentUUID) {
-                                                $scope.selected_agent = $scope.agents[i];
-                                                $scope.agent = $scope.agents[i];
-                                            }
+                                case 'server-info':
+                                    $timeout(function () {
+                                    for (var i = 0; i < $scope.agents.length; i++) {
+                                        if ($scope.agents[i].ParentUUID === $scope.instance.ParentUUID) {
+                                            $scope.selected_agent = $scope.agents[i];
+                                            $scope.agent = $scope.agents[i];
                                         }
+                                    }
 
-                                        $scope.getServerSummary($scope.agent);
-                                        $scope.getMySQLSummary($scope.agent);
-                                        }, 200);
-
-                                    break
+                                    $scope.getServerSummary($scope.agent);
+                                    $scope.getMySQLSummary($scope.agent);
+                                    }, 200);
+                                    break;
                                 default:
                                     $scope.MySQLUUID = false;
                                     break;


### PR DESCRIPTION
Reverts condition `if subsystem == 'mysql'` to `if subsystem != 'agent' && subsystem != 'os'`

This shouldn't brake anything and it allows adding new instance types to QAN beside `mysql`