### PR TITLE
PMM-1899: Show proper error when explaining truncated query.

### DIFF
--- a/src/app/mongo-query-details/mongo-query-details.component.ts
+++ b/src/app/mongo-query-details/mongo-query-details.component.ts
@@ -88,6 +88,13 @@ export class MongoQueryDetailsComponent extends CoreComponent implements OnInit 
     }
 
     const query = this.queryDetails.Example.Query;
+    const size = this.queryDetails.Example.Size;
+    if (size > 0 && size > query.length) {
+      this.errExplain = 'Cannot explain truncated query. This query was '+size+' bytes long and was truncated to maximum size of '+query.length+' bytes.';
+      this.isExplainLoading = false;
+      return
+    }
+
     let data = await this.queryDetailsService.getExplain(agentUUID, dbServerUUID, this.dbName, query);
     try {
       if (data.Error === '') {

--- a/src/app/mongo-query-details/mongo-query-details.service.ts
+++ b/src/app/mongo-query-details/mongo-query-details.service.ts
@@ -21,6 +21,7 @@ export interface QueryExample {
     Db: string;
     QueryTime: number;
     Query: string;
+    Size: number;
 };
 
 export interface QueryDetails {

--- a/src/app/mysql-query-details/mysql-query-details.component.ts
+++ b/src/app/mysql-query-details/mysql-query-details.component.ts
@@ -104,6 +104,12 @@ export class MySQLQueryDetailsComponent extends CoreComponent implements OnInit 
     }
 
     const query = this.queryDetails.Example.Query;
+    const size = this.queryDetails.Example.Size;
+    if (size > 0 && size > query.length) {
+        this.classicExplainError = this.jsonExplainError = 'Cannot explain truncated query. This query was '+size+' bytes long and was truncated to maximum size of '+query.length+' bytes.';
+        this.isExplainLoading = false;
+        return
+    }
 
     try {
       let data = await this.queryDetailsService.getExplain(agentUUID, dbServerUUID, this.dbName, query);

--- a/src/app/mysql-query-details/mysql-query-details.service.ts
+++ b/src/app/mysql-query-details/mysql-query-details.service.ts
@@ -20,6 +20,7 @@ export interface QueryExample {
     Db: string;
     QueryTime: number;
     Query: string;
+    Size: number;
 };
 
 export interface QueryDetails {


### PR DESCRIPTION
Show proper error if query got truncated.

Related PRs:
* https://github.com/percona/qan-api/pull/52
* https://github.com/percona/go-mysql/pull/28
* https://github.com/percona/qan-app/pull/79
* https://github.com/percona/pmm/pull/135