### PR TITLE
Updated renamed linter rules

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -99,9 +99,9 @@
 
     "directive-selector": [true, "attribute", "app", "camelCase"],
     "component-selector": [true, "element", "app", "kebab-case"],
-    "use-input-property-decorator": true,
-    "use-output-property-decorator": true,
-    "use-host-property-decorator": true,
+    "no-inputs-metadata-property": true,
+    "no-outputs-metadata-property": true,
+    "no-host-metadata-property": true,
     "no-input-rename": true,
     "no-output-rename": true,
     "use-life-cycle-interface": true,


### PR DESCRIPTION
I found some rules are deprecated.
```
horie at MBP in ~/src/github.com/percona/qan-app on master
$ npm run lint

> qan-app@1.17.2 lint /Users/horie/src/github.com/percona/qan-app
> ng lint

Linting "qan-app"...

Could not find implementations for the following rules specified in the configuration:
    use-input-property-decorator
    use-output-property-decorator
    use-host-property-decorator
Try upgrading TSLint and/or ensuring that you have all necessary custom rules installed.
If TSLint was recently upgraded, you may have old rules configured which need to be cleaned up.
        
All files pass linting.
Linting "qan-app-e2e"...
All files pass linting.
```

I updated some rules based on this comment.
https://github.com/mgechev/codelyzer/issues/791#issuecomment-474031004